### PR TITLE
Update check_before_use.sh

### DIFF
--- a/scripts/check_before_use.sh
+++ b/scripts/check_before_use.sh
@@ -21,7 +21,7 @@ else
 	MAJORVER="1"
 	MINRELEASE="0"
 	MINVERSION="0"
-	_RELEASE=`sudo -u root -S /usr/bin/vtlcmd -V| awk '{print $2}'|cut -d "-" -f1`
+	_RELEASE=`sudo -u root -S /usr/bin/vtlcmd -V 2>&1| awk '{print $2}'|cut -d "-" -f1`
 	MAJ=`echo $_RELEASE|awk -F. '{print $1}'`
 	RELEASE=`echo $_RELEASE|awk -F. '{print $2}'`
 	VERSION=`echo $_RELEASE|awk -F. '{print $3}'`


### PR DESCRIPTION
Hi there,

Looks like later mhvtl vtlcmd versions output -V to stderr, so this line won't catch the current version. Here's a quick hack to catch that so the gui will work.